### PR TITLE
MAINT(docker): Docker Compose UDP Support

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     build: github.com/mumble-voip/mumble#master
     container_name: mumble-server
     ports:
-        - 64738:64738
+        - 64738:64738/tcp
+        - 64738:64738/udp
     volumes:
       - ./murmur.ini:/etc/murmur/murmur.ini
       - ./data:/var/lib/murmur/


### PR DESCRIPTION
This adds support for UDP to the docker compose file. Without it will only allow TCP traffic.
### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

